### PR TITLE
Small stability improvement 

### DIFF
--- a/win32-darkmode/DarkMode.h
+++ b/win32-darkmode/DarkMode.h
@@ -106,7 +106,14 @@ bool IsHighContrast()
 
 void RefreshTitleBarThemeColor(HWND hWnd)
 {
-	BOOL dark = FALSE;
+	//Ensure that dark has the correct width
+#if _WIN64
+	UINT64 dark = FALSE;
+#elif _WIN32
+	UINT32 dark = FALSE;
+#else
+#error void* size not predetermined. Please look it up and add it here
+#endif
 	if (_IsDarkModeAllowedForWindow(hWnd) &&
 		_ShouldAppsUseDarkMode() &&
 		!IsHighContrast())

--- a/win32-darkmode/IatHook.h
+++ b/win32-darkmode/IatHook.h
@@ -22,6 +22,7 @@ constexpr T DataDirectoryFromModuleBase(void *moduleBase, size_t entryID)
 
 PIMAGE_THUNK_DATA FindAddressByName(void *moduleBase, PIMAGE_THUNK_DATA impName, PIMAGE_THUNK_DATA impAddr, const char *funcName)
 {
+	if (!moduleBase)return NULL;
 	for (; impName->u1.Ordinal; ++impName, ++impAddr)
 	{
 		if (IMAGE_SNAP_BY_ORDINAL(impName->u1.Ordinal))
@@ -37,6 +38,7 @@ PIMAGE_THUNK_DATA FindAddressByName(void *moduleBase, PIMAGE_THUNK_DATA impName,
 
 PIMAGE_THUNK_DATA FindAddressByOrdinal(void *moduleBase, PIMAGE_THUNK_DATA impName, PIMAGE_THUNK_DATA impAddr, uint16_t ordinal)
 {
+	if (!moduleBase)return NULL;
 	for (; impName->u1.Ordinal; ++impName, ++impAddr)
 	{
 		if (IMAGE_SNAP_BY_ORDINAL(impName->u1.Ordinal) && IMAGE_ORDINAL(impName->u1.Ordinal) == ordinal)
@@ -47,6 +49,7 @@ PIMAGE_THUNK_DATA FindAddressByOrdinal(void *moduleBase, PIMAGE_THUNK_DATA impNa
 
 PIMAGE_THUNK_DATA FindIatThunkInModule(void *moduleBase, const char *dllName, const char *funcName)
 {
+	if (!moduleBase)return NULL;
 	auto imports = DataDirectoryFromModuleBase<PIMAGE_IMPORT_DESCRIPTOR>(moduleBase, IMAGE_DIRECTORY_ENTRY_IMPORT);
 	for (; imports->Name; ++imports)
 	{
@@ -62,6 +65,7 @@ PIMAGE_THUNK_DATA FindIatThunkInModule(void *moduleBase, const char *dllName, co
 
 PIMAGE_THUNK_DATA FindDelayLoadThunkInModule(void *moduleBase, const char *dllName, const char *funcName)
 {
+	if (!moduleBase)return NULL;
 	auto imports = DataDirectoryFromModuleBase<PIMAGE_DELAYLOAD_DESCRIPTOR>(moduleBase, IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT);
 	for (; imports->DllNameRVA; ++imports)
 	{
@@ -77,6 +81,7 @@ PIMAGE_THUNK_DATA FindDelayLoadThunkInModule(void *moduleBase, const char *dllNa
 
 PIMAGE_THUNK_DATA FindDelayLoadThunkInModule(void *moduleBase, const char *dllName, uint16_t ordinal)
 {
+	if (!moduleBase)return NULL;
 	auto imports = DataDirectoryFromModuleBase<PIMAGE_DELAYLOAD_DESCRIPTOR>(moduleBase, IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT);
 	for (; imports->DllNameRVA; ++imports)
 	{


### PR DESCRIPTION
If comctl32.dll has not been loaded for some reason, `FixDarkScrollBar` will crash the application. The changes in IatHook.h ensure that a null moduleBase is not accepted and FixDarkScrollBar returns without crashes. (This may not be immediately relevant to the demo application, but the issue may arise in derivatives)

The second fix is for `reinterpret_cast<HANDLE>(dark)`.
If the application is built for 64 bit systems `HANDLE` converts to a `void *` with a width of 64 Bit.
But `BOOL` remains an `int`. Reinterpreting the smaller type to a larger one can potentially cause fatal crashes because the new 32 bits are random data. To fix this I have added a preprocessor check, but this may be solved a bit more elegantly. 